### PR TITLE
Add release CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,12 +40,13 @@ jobs:
       matrix:
         charm:
           - path: .
-            channel: 1/edge
+            track: 1
     needs:
       - lib-check
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v34.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v35.0.2
     with:
+      track: ${{ matrix.charm.track }}
       channel: ${{ matrix.charm.channel }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm.path }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@
 name: Release to Charmhub
 
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@
 name: Release to Charmhub
 
 on:
-  pull_request:
   push:
     branches:
       - main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,7 +47,6 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v35.0.2
     with:
       track: ${{ matrix.charm.track }}
-      channel: ${{ matrix.charm.channel }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm.path }}
     secrets:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           # FIXME: CHARMHUB_TOKEN will expire in 2026-09-09
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
-          github-token: "${{ secrets.CI_GITHUB_TOKEN }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
   ci-tests:
     needs:
       - lib-check

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+name: Release to Charmhub
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  lib-check:
+    name: Check libraries
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - run: |
+          # Workaround for https://github.com/canonical/charmcraft/issues/1389#issuecomment-1880921728
+          touch requirements.txt
+      - name: Check libs
+        uses: canonical/charming-actions/check-libraries@2.7.0
+        with:
+          # FIXME: CHARMHUB_TOKEN will expire in 2026-08-26
+          credentials: "${{ secrets.CHARMHUB_TOKEN }}"
+          github-token: "${{ secrets.CI_GITHUB_TOKEN }}"
+  ci-tests:
+    needs:
+      - lib-check
+    name: Tests
+    uses: ./.github/workflows/ci.yaml
+    secrets: inherit
+
+  release:
+    name: Release charm
+    strategy:
+      matrix:
+        charm:
+          - path: .
+            channel: latest/edge
+    needs:
+      - lib-check
+      - ci-tests
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v34.0.1
+    with:
+      channel: ${{ matrix.charm.channel }}
+      artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
+      path-to-charm-directory: ${{ matrix.charm.path }}
+    secrets:
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+    permissions:
+      contents: write # Needed to create git tags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@2.7.0
         with:
-          # FIXME: CHARMHUB_TOKEN will expire in 2026-08-26
+          # FIXME: CHARMHUB_TOKEN will expire in 2026-09-09
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.CI_GITHUB_TOKEN }}"
   ci-tests:
@@ -40,7 +40,7 @@ jobs:
       matrix:
         charm:
           - path: .
-            channel: latest/edge
+            channel: 1/edge
     needs:
       - lib-check
       - ci-tests

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -70,7 +70,7 @@ def test_config_options(juju: jubilant.Juju):
     secret_uri = juju.add_secret("fake-secret", {"test-key": "test-value"})
     juju.remove_secret(secret_uri)
     juju.config(APP_NAME, {"credentials": secret_uri})
-    juju.wait(jubilant.all_agents_idle)
+    juju.wait(jubilant.all_agents_idle, delay=5.0)
     status = juju.wait(
         lambda status: jubilant.all_blocked(status, APP_NAME),
     )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -51,16 +51,16 @@ def test_on_start_blocked(ctx: Context[AzureAuthIntegratorCharm], base_state: St
     assert "credentials" in status.message
 
 
-def test_on_start_no_secret_access_blocked(ctx: Context[AzureAuthIntegratorCharm], base_state: State, charm_configuration: dict):
+def test_on_start_no_secret_access_blocked(
+    ctx: Context[AzureAuthIntegratorCharm], base_state: State, charm_configuration: dict
+):
     """Tests that the charm's status is blocked if not granted secret access."""
     # Arrange
     charm_configuration["options"]["subscription-id"]["default"] = "subscriptionid"
     charm_configuration["options"]["tenant-id"]["default"] = "tenantid"
     # This secret does not exist
     charm_configuration["options"]["credentials"]["default"] = "secret:1a2b3c4d5e6f7g8h9i0j"
-    ctx = Context(
-        AzureAuthIntegratorCharm, meta=METADATA, config=charm_configuration, unit_id=0
-    )
+    ctx = Context(AzureAuthIntegratorCharm, meta=METADATA, config=charm_configuration, unit_id=0)
     state_in = base_state
 
     # Act
@@ -68,7 +68,7 @@ def test_on_start_no_secret_access_blocked(ctx: Context[AzureAuthIntegratorCharm
 
     # Assert
     assert isinstance(status := state_out.unit_status, BlockedStatus)
-    assert "does not exist" in status.message    
+    assert "does not exist" in status.message
 
 
 def test_on_start_active(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -8,11 +8,10 @@ import json
 import logging
 from pathlib import Path
 
-from ops.model import ActiveStatus, BlockedStatus
-from ops.testing import Context, Relation, Secret, State
 import pytest
 import yaml
-
+from ops.model import ActiveStatus, BlockedStatus
+from ops.testing import Context, Relation, Secret, State
 from src.charm import AzureAuthIntegratorCharm
 
 CONFIG = yaml.safe_load(Path("./config.yaml").read_text())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -70,10 +70,10 @@ def test_on_start_no_secret_access_blocked(
     assert "does not exist" in status.message
 
 
-def test_on_start_missing_secret_values(
+def test_on_start_missing_secret_fields(
     ctx: Context[AzureAuthIntegratorCharm], base_state: State, charm_configuration: dict
 ):
-    """Tests that the charm's status is blocked if the secret is missing the required values."""
+    """Tests that the charm's status is blocked if the secret is missing the required fields."""
     # Arrange
     credentials_secret = Secret(
         tracked_content={


### PR DESCRIPTION
Closes #6

This PR adds a `release.yaml` that is triggered on every push to `main`, packs the `azure-auth-integrator` charm and releases it to the `1/edge` channel

Note that we also increase the `delay` during integration tests in order to ensure that changes have been propagated after adding a secret.