### PR TITLE
feat: extra charm configs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,14 @@
 options:
+  container:
+    type: string
+    description: The name of the Azure Storage Container.
+  storage-account:
+    type: string
+    description: The name of the Azure storage account.
+  path:
+    type: string
+    description: The path inside the bucket/container to store objects.
+    default: ''
   subscription-id:
     type: string
     description: |

--- a/src/constants.py
+++ b/src/constants.py
@@ -6,6 +6,8 @@
 AZURE_SERVICE_PRINCIPAL_RELATION_NAME = "azure-service-principal-credentials"
 
 AZURE_SERVICE_PRINCIPAL_MANDATORY_OPTIONS = [
+    "container",
+    "storage-account",
     "subscription-id",
     "tenant-id",
     "credentials",

--- a/src/core/context.py
+++ b/src/core/context.py
@@ -33,6 +33,9 @@ class Context(WithLogging):
             return None
 
         return AzureServicePrincipalInfo(
+            storage_account=self.charm_config.get("storage-account"),
+            container=self.charm_config.get("container"),
+            path=self.charm_config.get("path"),
             subscription_id=self.charm_config.get("subscription-id"),
             tenant_id=self.charm_config.get("tenant-id"),
             client_id=secret_dict.get("client-id"),

--- a/src/core/domain.py
+++ b/src/core/domain.py
@@ -10,10 +10,13 @@ from dataclasses import dataclass
 class AzureServicePrincipalInfo:
     """Azure service principal parameters."""
 
+    storage_account: str
+    container: str
     subscription_id: str
     tenant_id: str
     client_id: str
     client_secret: str
+    path: str = ""
 
     def to_dict(self) -> dict:
         """Return the Azure service principal parameters as a dictionary."""
@@ -22,5 +25,8 @@ class AzureServicePrincipalInfo:
             "tenant-id": self.tenant_id,
             "client-id": self.client_id,
             "client-secret": self.client_secret,
+            "storage-account": self.storage_account,
+            "container": self.container,
+            "path": self.path,
         }
         return data

--- a/src/lib/azure_service_principal.py
+++ b/src/lib/azure_service_principal.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 AZURE_SERVICE_PRINCIPAL_REQUIRED_INFO = [
+    "storage-account",
+    "container",
     "subscription-id",
     "tenant-id",
     "client-id",

--- a/tests/integration/test-charm-azure-service-principal/src/lib/azure_service_principal.py
+++ b/tests/integration/test-charm-azure-service-principal/src/lib/azure_service_principal.py
@@ -26,6 +26,8 @@ logger = logging.getLogger(__name__)
 
 
 AZURE_SERVICE_PRINCIPAL_REQUIRED_INFO = [
+    "storage-account",
+    "container",
     "subscription-id",
     "tenant-id",
     "client-id",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -57,6 +57,8 @@ def test_on_start_no_secret_access_blocked(
     # Arrange
     charm_configuration["options"]["subscription-id"]["default"] = "subscriptionid"
     charm_configuration["options"]["tenant-id"]["default"] = "tenantid"
+    charm_configuration["options"]["storage-account"]["default"] = "storageaccount"
+    charm_configuration["options"]["container"]["default"] = "containername"
     # This secret does not exist
     charm_configuration["options"]["credentials"]["default"] = "secret:1a2b3c4d5e6f7g8h9i0j"
     ctx = Context(AzureAuthIntegratorCharm, meta=METADATA, config=charm_configuration, unit_id=0)
@@ -82,6 +84,8 @@ def test_on_start_missing_secret_fields(
     )
     charm_configuration["options"]["subscription-id"]["default"] = "subscriptionid"
     charm_configuration["options"]["tenant-id"]["default"] = "tenantid"
+    charm_configuration["options"]["storage-account"]["default"] = "storageaccount"
+    charm_configuration["options"]["container"]["default"] = "containername"
     charm_configuration["options"]["credentials"]["default"] = credentials_secret.id
     ctx = Context(AzureAuthIntegratorCharm, meta=METADATA, config=charm_configuration, unit_id=0)
     state_in = dataclasses.replace(base_state, secrets={credentials_secret})
@@ -107,6 +111,8 @@ def test_on_start_active(
     )
     charm_configuration["options"]["subscription-id"]["default"] = "subscriptionid"
     charm_configuration["options"]["tenant-id"]["default"] = "tenantid"
+    charm_configuration["options"]["storage-account"]["default"] = "storageaccount"
+    charm_configuration["options"]["container"]["default"] = "containername"
     charm_configuration["options"]["credentials"]["default"] = credentials_secret.id
     ctx = Context(AzureAuthIntegratorCharm, meta=METADATA, config=charm_configuration, unit_id=0)
     state_in = dataclasses.replace(base_state, secrets={credentials_secret})
@@ -131,6 +137,9 @@ def test_relation_application_data(
     )
     charm_configuration["options"]["subscription-id"]["default"] = "subscriptionid"
     charm_configuration["options"]["tenant-id"]["default"] = "tenantid"
+    charm_configuration["options"]["storage-account"]["default"] = "storageaccount"
+    charm_configuration["options"]["container"]["default"] = "containername"
+    charm_configuration["options"]["path"]["default"] = "test/path"
     charm_configuration["options"]["credentials"]["default"] = credentials_secret.id
     ctx = Context(AzureAuthIntegratorCharm, meta=METADATA, config=charm_configuration, unit_id=0)
     azure_service_principal_relation = Relation(endpoint="azure-service-principal-credentials")
@@ -148,3 +157,6 @@ def test_relation_application_data(
     assert provider_data["tenant-id"] == "tenantid"
     assert provider_data["client-id"] == "clientid"
     assert provider_data["client-secret"] == "clientsecret"
+    assert provider_data["storage-account"] == "storageaccount"
+    assert provider_data["container"] == "containername"
+    assert provider_data["path"] == "test/path"


### PR DESCRIPTION
This adds the `container`, `path`, and `storage-account` charm configs, which are usually required to configure the connection to the object storage.

Closes: #14 