### PR TITLE
feat: Publish `azure_service_principal library` to Charmhub

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,10 +37,10 @@ jobs:
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 6
+    timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install tox & poetry
         run: |
           pipx install tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Install tox & poetry
         run: |
           pipx install tox
@@ -37,7 +37,7 @@ jobs:
   unit-test:
     name: Unit tests
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 6
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - name: Setup environment
         run: |
           sudo apt-get remove -y docker-ce docker-ce-cli containerd.io

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,19 @@ jobs:
       path-to-charm-directory: ${{ matrix.path }}
       cache: false
 
+  release-to-test-branch:
+    name: Release charm to test branch
+    needs:
+      - build
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_pr.yaml@v42.0.2
+    with:
+      track: "1"
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+    secrets:
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+    permissions:
+      contents: write # Needed to create git tags
+
   integration-test:
     name: Run charm integration tests
     needs:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
     name: Release charm to test branch
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_pr.yaml@v42.0.2
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_pr.yaml@v42.0.1
     with:
       track: "1"
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - run: |
@@ -24,7 +24,7 @@ jobs:
       - name: Check libs
         uses: canonical/charming-actions/check-libraries@2.7.0
         with:
-          # FIXME: CHARMHUB_TOKEN will expire in 2026-09-09
+          # FIXME: CHARMHUB_TOKEN will expire in 2027-03-09
           credentials: "${{ secrets.CHARMHUB_TOKEN }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
   ci-tests:
@@ -53,3 +53,23 @@ jobs:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       contents: write # Needed to create git tags
+
+
+  release-library:
+    needs:
+      - lib-check
+      - ci-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install charmcraft
+        run: sudo snap install charmcraft --channel=3.x/stable --classic
+      - name: Install noctua
+        run: pipx install git+https://github.com/lucabello/noctua
+      - name: Release any bumped charm libs
+        env:
+          CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
+        run:
+          noctua charm libraries publish

--- a/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
+++ b/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
+++ b/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 import logging

--- a/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
+++ b/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
@@ -1,3 +1,43 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library to manage Azure Service Principal credentials.
+
+The design of the interface and the library has been specified in:
+https://docs.google.com/document/d/1RvpKpL2nxwzFmPHX9NJGe1h3J0lPQ_YltXROIB1TicI/edit?tab=t.0.
+
+This library contains a Requirer and a Provider for handling the relation and transmission
+of Azure Service Principal credentials.
+
+It makes use of the `data_interfaces` Charmhub hosted-library in order to transmit sensitive
+information as secrets. The source code is located in https://github.com/canonical/data-platform-libs
+
+The library also provides custom events to relay information about the status of the
+credentials.
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "d414f5220cf348f8bad08f13e6ec4a5b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
 import logging
 from typing import Dict
 
@@ -216,3 +256,4 @@ class AzureServicePrincipalProvider(EventHandlers):
             attr_name = field.replace("-", "_")
             setattr(model, attr_name, response_data[field])
         self.interface.write_model(relation.id, model)
+

--- a/src/events/lifecycle.py
+++ b/src/events/lifecycle.py
@@ -12,7 +12,7 @@ from ops.charm import (
 from constants import AZURE_SERVICE_PRINCIPAL_RELATION_NAME
 from core.context import Context
 from events.base import BaseEventHandler
-from lib.azure_service_principal import (
+from charms.azure_auth_integrator.v0.azure_service_principal import (
     AzureServicePrincipalProvider,
     ServicePrincipalInfoRequestedEvent,
 )

--- a/src/events/lifecycle.py
+++ b/src/events/lifecycle.py
@@ -4,6 +4,10 @@
 """Azure Service Principal provider related event handlers."""
 
 import ops
+from charms.azure_auth_integrator.v0.azure_service_principal import (
+    AzureServicePrincipalProvider,
+    ServicePrincipalInfoRequestedEvent,
+)
 from ops import CharmBase
 from ops.charm import (
     ConfigChangedEvent,
@@ -12,10 +16,6 @@ from ops.charm import (
 from constants import AZURE_SERVICE_PRINCIPAL_RELATION_NAME
 from core.context import Context
 from events.base import BaseEventHandler
-from charms.azure_auth_integrator.v0.azure_service_principal import (
-    AzureServicePrincipalProvider,
-    ServicePrincipalInfoRequestedEvent,
-)
 from utils.logging import WithLogging
 
 

--- a/tests/integration/test-charm-azure-service-principal/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
+++ b/tests/integration/test-charm-azure-service-principal/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
@@ -256,4 +256,3 @@ class AzureServicePrincipalProvider(EventHandlers):
             attr_name = field.replace("-", "_")
             setattr(model, attr_name, response_data[field])
         self.interface.write_model(relation.id, model)
-

--- a/tests/integration/test-charm-azure-service-principal/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
+++ b/tests/integration/test-charm-azure-service-principal/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.
+# Copyright 2026 Canonical Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 
 import logging

--- a/tests/integration/test-charm-azure-service-principal/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
+++ b/tests/integration/test-charm-azure-service-principal/lib/charms/azure_auth_integrator/v0/azure_service_principal.py
@@ -1,3 +1,43 @@
+# Copyright 2025 Canonical Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Library to manage Azure Service Principal credentials.
+
+The design of the interface and the library has been specified in:
+https://docs.google.com/document/d/1RvpKpL2nxwzFmPHX9NJGe1h3J0lPQ_YltXROIB1TicI/edit?tab=t.0.
+
+This library contains a Requirer and a Provider for handling the relation and transmission
+of Azure Service Principal credentials.
+
+It makes use of the `data_interfaces` Charmhub hosted-library in order to transmit sensitive
+information as secrets. The source code is located in https://github.com/canonical/data-platform-libs
+
+The library also provides custom events to relay information about the status of the
+credentials.
+"""
+
+# The unique Charmhub library identifier, never change it
+LIBID = "d414f5220cf348f8bad08f13e6ec4a5b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
 import logging
 from typing import Dict
 
@@ -216,3 +256,4 @@ class AzureServicePrincipalProvider(EventHandlers):
             attr_name = field.replace("-", "_")
             setattr(model, attr_name, response_data[field])
         self.interface.write_model(relation.id, model)
+

--- a/tests/integration/test-charm-azure-service-principal/src/charm.py
+++ b/tests/integration/test-charm-azure-service-principal/src/charm.py
@@ -14,7 +14,7 @@ from ops.charm import ActionEvent, CharmBase, RelationJoinedEvent
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus
 
-from lib.azure_service_principal import (
+from charms.azure_auth_integrator.v0.azure_service_principal import (
     AzureServicePrincipalRequirer,
     ServicePrincipalInfoChangedEvent,
     ServicePrincipalInfoGoneEvent,

--- a/tests/integration/test-charm-azure-service-principal/src/charm.py
+++ b/tests/integration/test-charm-azure-service-principal/src/charm.py
@@ -10,15 +10,14 @@ the azure service principal requires-provides relation.
 
 import logging
 
-from ops.charm import ActionEvent, CharmBase, RelationJoinedEvent
-from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus
-
 from charms.azure_auth_integrator.v0.azure_service_principal import (
     AzureServicePrincipalRequirer,
     ServicePrincipalInfoChangedEvent,
     ServicePrincipalInfoGoneEvent,
 )
+from ops.charm import ActionEvent, CharmBase, RelationJoinedEvent
+from ops.main import main
+from ops.model import ActiveStatus, BlockedStatus
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR is part of publishing of the `azure_service_principal` library to Charmhub. Changes include:
- Updating `azure-auth-integrator` and the `test-charm-azure-service-principal` to use the libraries from Charmhub instead of the local copies.
- Updating the CI to also publish the library when changes are detected.
- Updating the CI to publish the `azure-auth-integrator` charm when a PR is created for ease of development.