### PR TITLE
fix: Release to test branch only on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,7 @@ jobs:
 
   release-to-test-branch:
     name: Release charm to test branch
+    if: ${{ github.event_name == 'pull_request' }}
     needs:
       - build
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_pr.yaml@v42.0.1


### PR DESCRIPTION
This PR updates `ci.yaml` to run the `release-to-test-branch` action only when a PR is raised. This is needed in order to skip that job when the PR is pushed to main, so that the Release actions in `release.yaml` run properly.